### PR TITLE
Fix documentation fo `get` callback

### DIFF
--- a/lib/memjs/memjs.js
+++ b/lib/memjs/memjs.js
@@ -96,9 +96,9 @@ Client.prototype.server = function(key) {
 //
 // Fetches the value at the given key with callback signature:
 //
-//     callback(err, value, key)
+//     callback(err, value, flags)
 //
-// _value_ and _key_ are both `Buffer`s.
+// _value_ and _flags_ are both `Buffer`s.
 // If the key is not found, the callback is invoked
 // with null for both arguments and no error.
 Client.prototype.get = function(key, callback) {


### PR DESCRIPTION
The documentation had, mistakenly, said that the second argument to the
callback for a `get` is the `key` when, in fact, it is the value
`flags`.

Fixes #55