### PR TITLE
Add in support for `stats(key)` command.

### DIFF
--- a/lib/memjs/memjs.js
+++ b/lib/memjs/memjs.js
@@ -354,18 +354,18 @@ Client.prototype.flush = function(callback) {
   }
 }
 
-// STATS
+// STATS_WITH_KEY
 //
-// Fetches memcache stats from each connected server. The callback is invoked 
-// **ONCE PER SERVER** and has the signature:
+// Sends a memcache stats command with a key to each connected server. The
+// callback is invoked **ONCE PER SERVER** and has the signature:
 //
 //     callback(err, server, stats)
 //
-// _server_ is the `"hostname:port"` of the server, and _stats_ is a
-// dictionary mapping the stat name to the value of the statistic as a string.
-Client.prototype.stats = function(callback) {
+// _server_ is the `"hostname:port"` of the server, and _stats_ is a dictionary
+// mapping the stat name to the value of the statistic as a string.
+Client.prototype.statsWithKey = function(key, callback) {
   this.seq++;
-  var request = makeRequestBuffer(0x10, '', '', '', this.seq);
+  var request = makeRequestBuffer(0x10, key, '', '', this.seq);
   var logger = this.options.logger;
 
   var handleStats = function(seq, serv) {
@@ -382,7 +382,8 @@ Client.prototype.stats = function(callback) {
         result[response.key.toString()] = response.val.toString();
         break;
       default:
-        var errorMessage = 'MemJS STATS: ' + errors[response.header.status];
+        var errorMessage = 'MemJS STATS (' + key + '): ' +
+          errors[response.header.status];
         logger.log(errorMessage, false);
         callback && callback(new Error(errorMessage), serv.host + ":" + serv.port, null);
       }
@@ -399,6 +400,35 @@ Client.prototype.stats = function(callback) {
   for (var i in this.servers) {
     handleStats(this.seq, this.servers[i]);
   }
+}
+
+
+// STATS
+//
+// Fetches memcache stats from each connected server. The callback is invoked 
+// **ONCE PER SERVER** and has the signature:
+//
+//     callback(err, server, stats)
+//
+// _server_ is the `"hostname:port"` of the server, and _stats_ is a
+// dictionary mapping the stat name to the value of the statistic as a string.
+Client.prototype.stats = function(callback) {
+  this.statsWithKey('', callback);
+}
+
+// RESET_STATS
+//
+// Reset the statistics each server is keeping back to zero. This doesn't clear
+// stats such as item count, but temporary stats such as total number of
+// connections over time.T
+//
+// The callback is invoked **ONCE PER SERVER** and has the signature:
+//
+//     callback(err, server)
+//
+// _server_ is the `"hostname:port"` of the server.
+Client.prototype.resetStats = function(callback) {
+  this.statsWithKey('reset', callback);
 }
 
 // QUIT

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Amit Levy",
   "name": "memjs",
   "description": "A memcache client for node using the binary protocol and SASL authentication",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "homepage": "http://github.com/alevy/memjs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This allows to send the `stats('reset')` command and to send
other ones such as `stats('items')`.