### PR TITLE
Fixing a couple innocuous but missing 'vars'

### DIFF
--- a/lib/memjs/memjs.js
+++ b/lib/memjs/memjs.js
@@ -484,7 +484,7 @@ Client.prototype.perform = function(key, request, callback, retries) {
   retries = retries || this.options.retries;
   var failover = this.options.failover;
   var failoverTime = this.options.failoverTime;
-  origRetries = retries;
+  var origRetries = retries;
   var logger = this.options.logger;
 
   var responseHandler = function(response) {

--- a/lib/memjs/server.js
+++ b/lib/memjs/server.js
@@ -50,7 +50,7 @@ Server.prototype.error = function(err) {
     this._socket.destroy(); 
     delete(this._socket);
   }
-  for (k in errcalls) {
+  for (var k in errcalls) {
     errcalls[k](err);
   }
 }


### PR DESCRIPTION
Spotted two missing `var` statements. They don't look dangerous, but they also don't look intentional.