### PR TITLE
Return buffer from makeAmountInitialAndExpiration

### DIFF
--- a/lib/memjs/utils.js
+++ b/lib/memjs/utils.js
@@ -32,7 +32,7 @@ exports.makeAmountInitialAndExpiration = function(amount, amountIfEmpty, expirat
   buf.writeUInt32BE(0, 8);
   buf.writeUInt32BE(amountIfEmpty, 12);
   buf.writeUInt32BE(expiration, 16);
-  return buf.toString()
+  return buf;
 }
 
 exports.makeExpiration = function(expiration) {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -19,3 +19,27 @@ exports.testMergeDontPresereParameterWhenUndefinedOrNull =
     assert.equal(2, result2.retries);
   }
 
+exports.testMakeAmountInitialAndExpiration = function(beforeExit, assert) {
+    var extras, buf, fixture;
+    extras = utils.makeAmountInitialAndExpiration(1, 1, 1);
+    fixture = new Buffer('0000000000000001000000000000000100000001', 'hex');
+    assert.equal(20, extras.length);
+    assert.equal(fixture.toString('hex'), extras.toString('hex'));
+    buf = new Buffer(extras);
+    assert.equal(20, buf.length);
+    assert.equal(fixture.toString('hex'), buf.toString('hex'));
+
+    extras = utils.makeAmountInitialAndExpiration(255, 1, 1);
+    fixture = new Buffer('00000000000000ff000000000000000100000001', 'hex');
+    assert.equal(20, extras.length);
+    assert.equal(fixture.toString('hex'), extras.toString('hex'));
+    buf = new Buffer(extras);
+    assert.equal(20, buf.length);
+    assert.equal(fixture.toString('hex'), buf.toString('hex'));
+}
+
+exports.testMakeRequestBufferExtrasLength = function(beforeExit, assert) {
+    extras = utils.makeAmountInitialAndExpiration(255, 1, 1);
+    var buf = utils.makeRequestBuffer(0, 'test', extras, 1, 0);
+    assert.equal(20, buf[4]);
+}


### PR DESCRIPTION
When incrementing by certain values it looks like the buffer -> string -> buffer conversion that happens to the `extras` part of the header can lead to data corruption. Specifically bytes like `FF` are treated as multibyte string in the utf-8 conversion, so the resultant header is too long and contains the wrong info. 

It's not clear to me that the buffer returned by `makeAmountInitialAndExpiration` should be converted to a string, and in my own usage simply removing that conversion prevents the issue. This PR removes that conversion and adds a couple tests.