### PR TITLE
Allow manual setting of initial value for increment/decrement

### DIFF
--- a/lib/memjs/memjs.js
+++ b/lib/memjs/memjs.js
@@ -256,14 +256,14 @@ Client.prototype.delete = function(key, callback) {
 
 // INCREMENT
 //
-// Increments the given _key_ in memcache. Defaults to `0` if the key is not
-// present. The _expires_ argument (passed
-// in last, after the callback) overrides the default expiration (see
-// `Client.create`). The callback signature is:
+// Increments the given _key_ in memcache. If the key is not
+// present, defaults to _initial_ if supplied, or `0` otherwise. The _expires_
+// argument (passed in last, after the callback) overrides the
+// default expiration (see `Client.create`). The callback signature is:
 //
 //     callback(err, success, value)
-Client.prototype.increment = function(key, amount, callback, expires) {
-  var extras = makeAmountInitialAndExpiration(amount, 0, (expires || this.options.expires));
+Client.prototype.increment = function(key, amount, callback, expires, initial) {
+  var extras = makeAmountInitialAndExpiration(amount, (initial || 0), (expires || this.options.expires));
   this.seq++;
   var request = makeRequestBuffer(5, key, extras, '', this.seq);
 
@@ -288,14 +288,14 @@ Client.prototype.increment = function(key, amount, callback, expires) {
 
 // DECREMENT
 //
-// Decrements the given _key_ in memcache. Defaults to `0` if the key is not
-// present. The _expires_ argument (passed
-// in last, after the callback) overrides the default expiration (see
-// `Client.create`). The callback signature is:
+// Decrements the given _key_ in memcache. If the key is not
+// present, defaults to _initial_ if supplied, or `0` otherwise. The _expires_
+// argument (passed in last, after the callback) overrides the
+// default expiration (see `Client.create`). The callback signature is:
 //
 //     callback(err, success)
-Client.prototype.decrement = function(key, amount, callback, expires) {
-  var extras = makeAmountInitialAndExpiration(amount, 0, (expires || this.options.expires));
+Client.prototype.decrement = function(key, amount, callback, expires, initial) {
+  var extras = makeAmountInitialAndExpiration(amount, (initial || 0), (expires || this.options.expires));
   this.seq++;
   var request = makeRequestBuffer(6, key, extras, '', this.seq);
 

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -455,12 +455,15 @@ exports.testIncrementSuccessful = function(beforeExit, assert) {
   var n = 0;
   var callbn = 0;
   var dummyServer = new MemJS.Server();
+
+  var expectedExtras = '\0\0\0\0\0\0\0\5\0\0\0\0\0\0\0\0\0\0\0\0';
+
   dummyServer.write = function(requestBuf) {
     request = MemJS.Utils.parseMessage(requestBuf);
     assert.equal(5, request.header.opcode);
     assert.equal('number-increment-test', request.key);
     assert.equal('', request.val);
-    assert.equal('\0\0\0\0\0\0\0\5\0\0\0\0\0\0\0\0\0\0\0\0',
+    assert.equal(expectedExtras,
                  request.extras.toString());
     n += 1;
     var value = new Buffer(8);
@@ -477,9 +480,17 @@ exports.testIncrementSuccessful = function(beforeExit, assert) {
     assert.equal(null, err);
   });
 
+  expectedExtras = '\0\0\0\0\0\0\0\5\0\0\0\0\0\0\0\3\0\0\0\0';
+  client.increment('number-increment-test', 5, function(err, success, val) {
+    callbn += 1;
+    assert.equal(true, success);
+    assert.equal(6, val);
+    assert.equal(null, err);
+  }, null, 3);
+
   beforeExit(function() {
-    assert.equal(1, callbn,  'Ensure callbacks are called');
-    assert.equal(1, n,       'Ensure incr is called');
+    assert.equal(2, callbn,  'Ensure callbacks are called');
+    assert.equal(2, n,       'Ensure incr is called');
   });
 }
 


### PR DESCRIPTION
Memcached allows setting an initial value for the increment and decrement operations, in case the requested key doesn't exist. At present, memjs always sets this to 0; this PR allows users to optionally specify it. A particular common pattern this allows is to use the same value for both the _value_ and _initial_ fields, to increment a key by that amount if it exists, or set to that amount if it doesn't. This allows emulating redis's increment/decrement behavior, among other things.

I also added another instance of the increment/decrement test that checks that this value is set correctly in the header. Ideally this ought to be tested against an actual memcached server, but that's probably better left to another PR.