### PR TITLE
Switch test runner to node-tap

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
     "lib" : "./lib/memjs"
   },
   "scripts": {
-    "test": "eslint lib/memjs/ && NODE_PATH=lib/memjs/ expresso",
+    "test": "eslint ./lib/memjs/ ./test/ && tap -R spec ./test/*.js",
     "bench": "NODE_PATH=lib/memjs/ node bench/memjs.js"
   },
   "dependencies": {},
   "devDependencies": {"eslint":"1.10.3",
-                      "expresso": "0.9.*",
+                      "tap": "4.0.*",
                       "benchmark": "2.0.*",
                       "microtime": "2.0.*"}
 }

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -1,430 +1,366 @@
-var errors = require('protocol').errors;
-var MemJS = require('memjs');
+var test = require('tap').test;
+var errors = require('../lib/memjs/protocol').errors;
+var MemJS = require('../');
 
-exports.testGetSuccessful = function(beforeExit, assert) {
+test('GetSuccessful', function(t) {
   var n = 0;
-  var callbn = 0;
   var dummyServer = new MemJS.Server();
   dummyServer.write = function(requestBuf) {
-    request = MemJS.Utils.parseMessage(requestBuf);
-    assert.equal('hello', request.key);
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal('hello', request.key.toString());
     n += 1;
     dummyServer.respond(
       {header: {status: 0, opaque: request.header.opaque},
         val: 'world', extras: 'flagshere'});
-  }
+  };
 
   var client = new MemJS.Client([dummyServer]);
   client.get('hello', function(err, val, flags) {
-    assert.equal('world', val);
-    assert.equal('flagshere', flags);
-    assert.equal(null, err);
-    callbn += 1;
+    t.equal('world', val);
+    t.equal('flagshere', flags);
+    t.equal(null, err);
+    t.equal(1, n,  'Ensure set is called');
+    t.end();
   });
+});
 
-  beforeExit(function() {
-    assert.equal(1, n,  'Ensure set is called');
-    assert.equal(1, callbn,  'Ensure callback is called');
-  });
-}
-
-exports.testGetNotFound = function(beforeExit, assert) {
+test('GetNotFound', function(t) {
   var n = 0;
-  var callbn = 0;
   var dummyServer = new MemJS.Server();
   dummyServer.write = function(requestBuf) {
-    request = MemJS.Utils.parseMessage(requestBuf);
-    assert.equal('hello', request.key);
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal('hello', request.key.toString());
     n += 1;
     dummyServer.respond(
       {header: {status: 1, opaque: request.header.opaque}});
-  }
+  };
 
   var client = new MemJS.Client([dummyServer]);
   client.get('hello', function(val, flags) {
-    assert.equal(null, val);
-    assert.equal(null, flags);
-    callbn += 1;
+    t.equal(null, val);
+    t.equal(null, flags);
+    t.equal(1, n,  'Ensure set is called');
+    t.end();
   });
+});
 
-  beforeExit(function() {
-    assert.equal(1, n,  'Ensure set is called');
-    assert.equal(1, callbn,  'Ensure callback is called');
-  });
-}
-
-exports.testSetSuccessful = function(beforeExit, assert) {
+test('SetSuccessful', function(t) {
   var n = 0;
-  var callbn = 0;
   var dummyServer = new MemJS.Server();
   dummyServer.write = function(requestBuf) {
-    request = MemJS.Utils.parseMessage(requestBuf);
-    assert.equal('hello', request.key);
-    assert.equal('world', request.val);
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal('hello', request.key.toString());
+    t.equal('world', request.val.toString());
     n += 1;
     dummyServer.respond({header: {status: 0, opaque: request.header.opaque}});
-  }
+  };
 
   var client = new MemJS.Client([dummyServer]);
   client.set('hello', 'world', function(err, val) {
-    assert.equal(true, val);
-    assert.equal(null, err);
-    callbn += 1;
+    t.equal(true, val);
+    t.equal(null, err);
+    t.equal(1, n,  'Ensure set is called');
+    t.end();
   });
+});
 
-  beforeExit(function() {
-    assert.equal(1, n,  'Ensure set is called');
-    assert.equal(1, callbn,  'Ensure callback is called');
-  });
-}
-
-exports.testSetWithExpiration = function(beforeExit, assert) {
+test('SetWithExpiration', function(t) {
   var n = 0;
-  var callbn = 0;
   var dummyServer = new MemJS.Server();
   dummyServer.write = function(requestBuf) {
-    request = MemJS.Utils.parseMessage(requestBuf);
-    assert.equal('hello', request.key);
-    assert.equal('world', request.val);
-    assert.equal('\0\0\0\0\0\0\4\0', request.extras.toString());
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal('hello', request.key.toString());
+    t.equal('world', request.val.toString());
+    t.equal('\0\0\0\0\0\0\4\0', request.extras.toString());
     n += 1;
     dummyServer.respond({header: {status: 0, opaque: request.header.opaque}});
-  }
+  };
 
   var client = new MemJS.Client([dummyServer], {expires: 1024});
   client.set('hello', 'world', function(err, val) {
-    assert.equal(null, err);
-    assert.equal(true, val);
-    callbn += 1;
+    t.equal(null, err);
+    t.equal(true, val);
+    t.equal(1, n,  'Ensure set is called');
+    t.end();
   });
+});
 
-  beforeExit(function() {
-    assert.equal(1, n,  'Ensure set is called');
-    assert.equal(1, callbn,  'Ensure callback is called');
-  });
-}
-
-exports.testSetUnsuccessful = function(beforeExit, assert) {
+test('SetUnsuccessful', function(t) {
   var n = 0;
-  var callbn = 0;
   var dummyServer = new MemJS.Server();
   dummyServer.write = function(requestBuf) {
-    request = MemJS.Utils.parseMessage(requestBuf);
-    assert.equal('hello', request.key);
-    assert.equal('world', request.val);
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal('hello', request.key.toString());
+    t.equal('world', request.val.toString());
     n += 1;
     dummyServer.respond({header: {status: 3, opaque: request.header.opaque}});
-  }
+  };
 
   var client = new MemJS.Client([dummyServer]);
   client.set('hello', 'world', function(err, val) {
-    assert.equal(undefined, val);
-    assert.equal("MemJS SET: " + errors[3], err.message);
-    callbn += 1;
+    t.equal(null, val);
+    t.equal('MemJS SET: ' + errors[3], err.message);
+    t.equal(1, n,  'Ensure set is called');
+    t.end();
   });
+});
 
-  beforeExit(function() {
-    assert.equal(1, n,  'Ensure set is called');
-    assert.equal(1, callbn,  'Ensure callback is called');
-  });
-}
-
-exports.testSetError = function(beforeExit, assert) {
+test('SetError', function(t) {
   var n = 0;
-  var callbn = 0;
   var dummyServer = new MemJS.Server();
   dummyServer.write = function(requestBuf) {
-    request = MemJS.Utils.parseMessage(requestBuf);
-    assert.equal('hello', request.key);
-    assert.equal('world', request.val);
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal('hello', request.key.toString());
+    t.equal('world', request.val.toString());
     n += 1;
-    dummyServer.error({message: "This is an expected error."});
-  }
+    dummyServer.error({message: 'This is an expected error.'});
+  };
 
   var client = new MemJS.Client([dummyServer]);
   client.set('hello', 'world', function(err, val) {
-    callbn += 1;
+    t.notEqual(null, err);
+    t.equal('This is an expected error.', err.message);
+    t.equal(null, val);
+    t.equal(2, n,  'Ensure set is retried once');
+    t.end();
   });
+});
 
-  beforeExit(function() {
-    assert.equal(2, n,  'Ensure set is retried once');
-    assert.equal(1, callbn,  'Ensure callback is called ' + callbn);
-  });
-}
-
-exports.testSetError = function(beforeExit, assert) {
+test('SetError', function(t) {
   var n = 0;
-  var callbn = 0;
-  var errn = 0;
   var dummyServer = new MemJS.Server();
   dummyServer.write = function(requestBuf) {
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal('hello', request.key.toString());
+    t.equal('world', request.val.toString());
     setTimeout(function() {
-      request = MemJS.Utils.parseMessage(requestBuf);
-      assert.equal('hello', request.key);
-      assert.equal('world', request.val);
       n += 1;
-      dummyServer.error({message: "This is an expected error."});
+      dummyServer.error({message: 'This is an expected error.'});
     }, 100);
-  }
+  };
 
   var client = new MemJS.Client([dummyServer], {retries: 2});
-  client.set('hello', 'world', function(err, val) {
-    if (err) {
-      errn += 1;
-    }
-    callbn += 1;
+  client.set('hello', 'world', function(err /*, val */) {
+    t.equal(2, n, 'Ensure set is retried once');
+    t.ok(err, 'Ensure callback called with error');
+    t.equal('This is an expected error.', err.message);
+    t.end();
   });
+});
 
-  beforeExit(function() {
-    assert.equal(2, n,  'Ensure set is retried once ' + n);
-    assert.equal(1, callbn,  'Ensure callback is called ' + callbn);
-    assert.equal(1, errn,  'Ensure callback called with error ' + errn);
-  });
-}
-
-exports.testSetErrorConcurrent = function(beforeExit, assert) {
+test('SetErrorConcurrent', function(t) {
   var n = 0;
   var callbn1 = 0;
-  var errn1 = 0;
   var callbn2 = 0;
-  var errn2 = 0;
   var dummyServer = new MemJS.Server();
-  dummyServer.write = function(requestBuf) {
-    setTimeout(function() {
-      request = MemJS.Utils.parseMessage(requestBuf);
+  dummyServer.write = function(/* requestBuf */) {
+    process.nextTick(function() {
       n += 1;
-      dummyServer.error({message: "This is an expected error."});
-    }, 100);
-  }
+      dummyServer.error({message: 'This is an expected error.'});
+    });
+  };
 
   var client = new MemJS.Client([dummyServer], {retries: 2});
-  client.set('hello', 'world', function(err, val) {
-    if (err) {
-      errn1 += 1;
-    }
+  client.set('hello', 'world', function(err /*, val */) {
+    t.ok(err, 'Ensure callback called with error');
+    t.equal('This is an expected error.', err.message);
     callbn1 += 1;
+    done();
   });
 
-  client.set('foo', 'bar', function(err, val) {
-    if (err) {
-      errn2 += 1;
-    }
+  client.set('foo', 'bar', function(err /*, val */) {
+    t.ok(err, 'Ensure callback called with error');
+    t.equal('This is an expected error.', err.message);
     callbn2 += 1;
+    done();
   });
 
-  beforeExit(function() {
-    assert.equal(4, n,  'Ensure set is retried once ' + n);
-    assert.equal(1, callbn1,  'Ensure callback is called ' + callbn1);
-    assert.equal(1, errn1,  'Ensure callback called with error ' + errn1);
-    assert.equal(1, callbn2,  'Ensure callback is called ' + callbn2);
-    assert.equal(1, errn2,  'Ensure callback called with error ' + errn2);
-  });
-}
+  var done =(function() {
+    var called = 0;
+    return function() {
+      called += 1;
+      if (called < 2) return; 
+      t.equal(2, n,  'Ensure error is sent');
+      t.equal(1, callbn1,  'Ensure callback 1 is called once');
+      t.equal(1, callbn2,  'Ensure callback 2 is called once');
+      process.nextTick(function() {
+        t.equal(1, callbn1,  'Ensure callback 1 is called once');
+        t.equal(1, callbn2,  'Ensure callback 2 is called once');
+        t.equal(4, n,  'Ensure error sent again');
+        t.end();
+      });
+    };
+  })();
+});
 
-exports.testSetUnicode = function(beforeExit, assert) {
+test('SetUnicode', function(t) {
   var n = 0;
-  var callbn = 0;
   var dummyServer = new MemJS.Server();
   dummyServer.write = function(requestBuf) {
-    request = MemJS.Utils.parseMessage(requestBuf);
-    assert.equal('hello', request.key);
-    assert.equal('éééoào', request.val);
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal('hello', request.key.toString());
+    t.equal('éééoào', request.val.toString());
     n += 1;
     dummyServer.respond({header: {status: 0, opaque: request.header.opaque}});
-  }
+  };
 
   var client = new MemJS.Client([dummyServer]);
   client.set('hello', 'éééoào', function(err, val) {
-    assert.equal(true, val);
-    callbn += 1;
+    t.equal(true, val);
+    t.equal(1, n,  'Ensure set is called');
+    t.end();
   });
+});
 
-  beforeExit(function() {
-    assert.equal(1, n,  'Ensure set is called');
-    assert.equal(1, callbn,  'Ensure callback is called');
-  });
-}
-
-exports.testAddSuccessful = function(beforeExit, assert) {
+test('AddSuccessful', function(t) {
   var n = 0;
-  var callbn = 0;
   var dummyServer = new MemJS.Server();
   dummyServer.write = function(requestBuf) {
-    request = MemJS.Utils.parseMessage(requestBuf);
-    assert.equal('hello', request.key);
-    assert.equal('world', request.val);
-    assert.equal('\0\0\0\0\0\0\4\0', request.extras.toString());
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal('hello', request.key.toString());
+    t.equal('world', request.val.toString());
+    t.equal('0000000000000400', request.extras.toString('hex'));
     n += 1;
     dummyServer.respond({header: {status: 0, opaque: request.header.opaque}});
-  }
+  };
 
   var client = new MemJS.Client([dummyServer], {expires: 1024});
   client.add('hello', 'world', function(err, val) {
-    assert.equal(null, err);
-    assert.equal(true, val);
-    callbn += 1;
+    t.equal(null, err);
+    t.equal(true, val);
+    t.equal(1, n,  'Ensure set is called');
+    t.end();
   });
+});
 
-  beforeExit(function() {
-    assert.equal(1, n,  'Ensure set is called');
-    assert.equal(1, callbn,  'Ensure callback is called');
-  });
-}
-
-exports.testAddKeyExists = function(beforeExit, assert) {
+test('AddKeyExists', function(t) {
   var n = 0;
-  var callbn = 0;
   var dummyServer = new MemJS.Server();
   dummyServer.write = function(requestBuf) {
-    request = MemJS.Utils.parseMessage(requestBuf);
-    assert.equal('hello', request.key);
-    assert.equal('world', request.val);
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal('hello', request.key.toString());
+    t.equal('world', request.val.toString());
     n += 1;
     dummyServer.respond({header: {status: 2, opaque: request.header.opaque}});
-  }
+  };
 
   var client = new MemJS.Client([dummyServer]);
   client.add('hello', 'world', function(err, val) {
-    assert.equal(null, err);
-    assert.equal(false, val);
-    callbn += 1;
+    t.equal(null, err);
+    t.equal(false, val);
+    t.equal(1, n,  'Ensure set is called');
+    t.end();
   });
+});
 
-  beforeExit(function() {
-    assert.equal(1, n,  'Ensure set is called');
-    assert.equal(1, callbn,  'Ensure callback is called');
-  });
-}
-
-exports.testReplaceSuccessful = function(beforeExit, assert) {
+test('ReplaceSuccessful', function(t) {
   var n = 0;
-  var callbn = 0;
   var dummyServer = new MemJS.Server();
   dummyServer.write = function(requestBuf) {
-    request = MemJS.Utils.parseMessage(requestBuf);
-    assert.equal('hello', request.key);
-    assert.equal('world', request.val);
-    assert.equal('\0\0\0\0\0\0\4\0', request.extras.toString());
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal('hello', request.key.toString());
+    t.equal('world', request.val.toString());
+    t.equal('\0\0\0\0\0\0\4\0', request.extras.toString());
     n += 1;
     dummyServer.respond({header: {status: 0, opaque: request.header.opaque}});
-  }
+  };
 
   var client = new MemJS.Client([dummyServer], {expires: 1024});
   client.replace('hello', 'world', function(err, val) {
-    assert.equal(null, err);
-    assert.equal(true, val);
-    callbn += 1;
+    t.equal(null, err);
+    t.equal(true, val);
+    t.equal(1, n,  'Ensure set is called');
+    t.end();
   });
+});
 
-  beforeExit(function() {
-    assert.equal(1, n,  'Ensure set is called');
-    assert.equal(1, callbn,  'Ensure callback is called');
-  });
-}
-
-exports.testReplaceKeyDNE = function(beforeExit, assert) {
+test('ReplaceKeyDNE', function(t) {
   var n = 0;
-  var callbn = 0;
   var dummyServer = new MemJS.Server();
   dummyServer.write = function(requestBuf) {
-    request = MemJS.Utils.parseMessage(requestBuf);
-    assert.equal('hello', request.key);
-    assert.equal('world', request.val);
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal('hello', request.key.toString());
+    t.equal('world', request.val.toString());
     n += 1;
     dummyServer.respond({header: {status: 1, opaque: request.header.opaque}});
-  }
+  };
 
   var client = new MemJS.Client([dummyServer]);
   client.replace('hello', 'world', function(err, val) {
-    assert.equal(null, err);
-    assert.equal(false, val);
-    callbn += 1;
+    t.equal(null, err);
+    t.equal(false, val);
+    t.equal(1, n,  'Ensure set is called');
+    t.end();
   });
+});
 
-  beforeExit(function() {
-    assert.equal(1, n,  'Ensure set is called');
-    assert.equal(1, callbn,  'Ensure callback is called');
-  });
-}
-
-exports.testDeleteSuccessful = function(beforeExit, assert) {
+test('DeleteSuccessful', function(t) {
   var n = 0;
-  var callbn = 0;
   var dummyServer = new MemJS.Server();
   dummyServer.write = function(requestBuf) {
-    request = MemJS.Utils.parseMessage(requestBuf);
-    assert.equal('hello', request.key);
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal('hello', request.key.toString());
     n += 1;
     dummyServer.respond({header: {status: 0, opaque: request.header.opaque}});
-  }
+  };
 
   var client = new MemJS.Client([dummyServer]);
   client.delete('hello', function(err, val) {
-    assert.equal(null, err);
-    assert.equal(true, val);
-    callbn += 1;
+    t.equal(null, err);
+    t.equal(true, val);
+    t.equal(1, n,  'Ensure set is called');
+    t.end();
   });
+});
 
-  beforeExit(function() {
-    assert.equal(1, n,  'Ensure set is called');
-    assert.equal(1, callbn,  'Ensure callback is called');
-  });
-}
-
-exports.testDeleteKeyDNE = function(beforeExit, assert) {
+test('DeleteKeyDNE', function(t) {
   var n = 0;
-  var callbn = 0;
   var dummyServer = new MemJS.Server();
   dummyServer.write = function(requestBuf) {
-    request = MemJS.Utils.parseMessage(requestBuf);
-    assert.equal('hello', request.key);
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal('hello', request.key.toString());
     n += 1;
     dummyServer.respond({header: {status: 1, opaque: request.header.opaque}});
-  }
+  };
 
   var client = new MemJS.Client([dummyServer]);
   client.delete('hello', function(err, val) {
-    assert.equal(null, err);
-    assert.equal(false, val);
-    callbn += 1;
+    t.equal(null, err);
+    t.equal(false, val);
+    t.equal(1, n,  'Ensure set is called');
+    t.end();
   });
+});
 
-  beforeExit(function() {
-    assert.equal(1, n,  'Ensure set is called');
-    assert.equal(1, callbn,  'Ensure callback is called');
-  });
-}
-
-exports.testFlush = function(beforeExit, assert) {
+test('Flush',  function(t) {
   var n = 0;
-  var callbn = 0;
   var dummyServer = new MemJS.Server();
-  dummyServer.host = "example.com";
+  dummyServer.host = 'example.com';
   dummyServer.port = 1234;
   dummyServer.write = function(requestBuf) {
-    request = MemJS.Utils.parseMessage(requestBuf);
-    assert.equal(0x08, request.header.opcode);
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal(0x08, request.header.opcode);
     n += 1;
     dummyServer.respond({header: {status: 1, opaque: request.header.opaque}});
-  }
+  };
 
   var client = new MemJS.Client([dummyServer, dummyServer]);
   client.flush(function(err, results) {
-    assert.equal(null, err);
-    assert.equal(true, results['example.com:1234']);
+    t.equal(null, err);
+    t.equal(true, results['example.com:1234']);
+    t.equal(2, n, 'Ensure flush is called for each server');
+    t.end();
   });
+});
 
-}
-
-exports.testStats = function(beforeExit, assert) {
+test('Stats', function(t) {
   var n = 0;
-  var callbn = 0;
   var dummyServer = new MemJS.Server();
-  dummyServer.host = "myhostname";
-  dummyServer.port = 5544
+  dummyServer.host = 'myhostname';
+  dummyServer.port = 5544;
   dummyServer.write = function(requestBuf) {
-    request = MemJS.Utils.parseMessage(requestBuf);
-    assert.equal(0x10, request.header.opcode);
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal(0x10, request.header.opcode);
     n += 1;
     dummyServer.respond({header: {status: 0, totalBodyLength: 9,
                                   opaque: request.header.opaque},
@@ -434,119 +370,121 @@ exports.testStats = function(beforeExit, assert) {
                         key: 'count', val: '5432'});
     dummyServer.respond({header: {status: 0, totalBodyLength: 0,
                                   opaque: request.header.opaque}});
-  }
+  };
 
   var client = new MemJS.Client([dummyServer]);
   client.stats(function(err, server, stats) {
-    assert.equal(null, err);
-    assert.equal('1432', stats.bytes);
-    assert.equal('5432', stats.count);
-    assert.equal('myhostname:5544', server);
-    callbn += 1;
+    t.equal(null, err);
+    t.equal('1432', stats.bytes);
+    t.equal('5432', stats.count);
+    t.equal('myhostname:5544', server);
+    t.equal(1, n,  'Ensure set is called');
+    t.end();
   });
+});
 
-  beforeExit(function() {
-    assert.equal(1, n,  'Ensure set is called');
-    assert.equal(1, callbn,  'Ensure callback is called');
-  });
-}
-
-exports.testIncrementSuccessful = function(beforeExit, assert) {
+test('IncrementSuccessful', function(t) {
   var n = 0;
   var callbn = 0;
   var dummyServer = new MemJS.Server();
 
-  var expectedExtras = '\0\0\0\0\0\0\0\5\0\0\0\0\0\0\0\0\0\0\0\0';
+  var expectedExtras = [
+    '\0\0\0\0\0\0\0\5\0\0\0\0\0\0\0\0\0\0\0\0',
+    '\0\0\0\0\0\0\0\5\0\0\0\0\0\0\0\3\0\0\0\0'
+  ];
 
   dummyServer.write = function(requestBuf) {
-    request = MemJS.Utils.parseMessage(requestBuf);
-    assert.equal(5, request.header.opcode);
-    assert.equal('number-increment-test', request.key);
-    assert.equal('', request.val);
-    assert.equal(expectedExtras,
-                 request.extras.toString());
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal(5, request.header.opcode);
+    t.equal('number-increment-test', request.key.toString());
+    t.equal('', request.val.toString());
+    t.equal(expectedExtras[n], request.extras.toString());
     n += 1;
-    var value = new Buffer(8);
-    value.writeUInt32BE(request.header.opcode + 1, 4);
-    value.writeUInt32BE(0, 0);
-    dummyServer.respond({header: {status: 0, opaque: request.header.opaque}, val: value});
-  }
+    process.nextTick(function() {
+      var value = new Buffer(8);
+      value.writeUInt32BE(request.header.opcode + 1, 4);
+      value.writeUInt32BE(0, 0);
+      dummyServer.respond({header: {status: 0, opaque: request.header.opaque}, val: value});
+    });
+  };
 
   var client = new MemJS.Client([dummyServer]);
   client.increment('number-increment-test', 5, function(err, success, val){
     callbn += 1;
-    assert.equal(true, success);
-    assert.equal(6, val);
-    assert.equal(null, err);
+    t.equal(true, success);
+    t.equal(6, val);
+    t.equal(null, err);
+    done();
   });
 
-  expectedExtras = '\0\0\0\0\0\0\0\5\0\0\0\0\0\0\0\3\0\0\0\0';
   client.increment('number-increment-test', 5, function(err, success, val) {
     callbn += 1;
-    assert.equal(true, success);
-    assert.equal(6, val);
-    assert.equal(null, err);
+    t.equal(true, success);
+    t.equal(6, val);
+    t.equal(null, err);
+    done();
   }, null, 3);
 
-  beforeExit(function() {
-    assert.equal(2, callbn,  'Ensure callbacks are called');
-    assert.equal(2, n,       'Ensure incr is called');
-  });
-}
+  var done =(function() {
+    var called = 0;
+    return function() {
+      called += 1;
+      if (called < 2) return; 
+      t.equal(2, n,  'Ensure increment is called twice');
+      t.equal(2, callbn,  'Ensure callback is called twice');
+      t.end();
+    };
+  })();
+});
 
-exports.testDecrementSuccessful = function(beforeExit, assert) {
+test('DecrementSuccessful', function(t) {
   var n = 0;
-  var callbn = 0;
   var dummyServer = new MemJS.Server();
   dummyServer.write = function(requestBuf) {
-    request = MemJS.Utils.parseMessage(requestBuf);
-    assert.equal(6, request.header.opcode);
-    assert.equal('number-decrement-test', request.key);
-    assert.equal('', request.val);
-    assert.equal('\0\0\0\0\0\0\0\5\0\0\0\0\0\0\0\0\0\0\0\0',
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal(6, request.header.opcode);
+    t.equal('number-decrement-test', request.key.toString());
+    t.equal('', request.val.toString());
+    t.equal('\0\0\0\0\0\0\0\5\0\0\0\0\0\0\0\0\0\0\0\0',
                  request.extras.toString());
     n += 1;
     dummyServer.respond({header: {status: 0, opaque: request.header.opaque}});
-  }
+  };
 
   var client = new MemJS.Client([dummyServer]);
   client.decrement('number-decrement-test', 5, function(err, val){
-    callbn += 1;
-    assert.equal(true, val);
-    assert.equal(null, err);
+    t.equal(true, val);
+    t.equal(null, err);
+    t.equal(1, n,       'Ensure decr is called');
+    t.end();
   });
+});
 
-  beforeExit(function() {
-    assert.equal(1, callbn,  'Ensure callbacks are called');
-    assert.equal(1, n,       'Ensure decr is called');
-  });
-}
-
-exports.testFailover = function(beforeExit, assert) {
+test('Failover', function(t) {
   var n1 = 0;
   var n2 = 0;
   var dummyServer1 = new MemJS.Server();
-  dummyServer1.write = function(requestBuf) {
+  dummyServer1.write = function(/* requestBuf*/) {
     n1 += 1;
-    dummyServer1.error(new Error("connection failure"));
-  }
+    dummyServer1.error(new Error('connection failure'));
+  };
   var dummyServer2 = new MemJS.Server();
   dummyServer2.write = function(requestBuf) {
     n2 += 1;
+    var request = MemJS.Utils.parseMessage(requestBuf);
     dummyServer2.respond({header: {status: 0, opaque: request.header.opaque}});
-  }
+  };
 
-  var client = new MemJS.Client([dummyServer1, dummyServer2],
-        {failover: true});
-  client.get('\0', function(err, val){
-    assert.equal(null, err);
+  var client = new MemJS.Client([dummyServer1, dummyServer2], {failover: true});
+  client.get('\0', function(err/*, val */){
+    t.equal(null, err);
+    t.equal(2, n1);
+    t.equal(1, n2);
+    t.end();
   });
 
-  beforeExit(function() {
-    assert.equal(2, n1);
-    assert.equal(1, n2);
-  });
-}
+});
+return;
 
 /*
 exports.testFailoverRecovery = function(beforeExit, assert) {

--- a/test/header_test.js
+++ b/test/header_test.js
@@ -1,21 +1,23 @@
-var header = require('header');
+var test = require('tap').test;
+var header = require('../lib/memjs/header');
 
-exports.testParseHeaderResponse = function(be, assert) {
+test('ParseHeaderResponse', function(t) {
   var headerBuf = new Buffer([0x81, 1, 7, 0, 4, 3, 0, 1, 0, 0, 0, 9, 0, 0, 0, 0, 0x0a, 0, 0, 0, 0, 0, 0, 0]);
   var responseHeader = header.fromBuffer(headerBuf);
-  assert.equal(0x81, responseHeader.magic);
-  assert.equal(1, responseHeader.opcode);
-  assert.equal(0x0700, responseHeader.keyLength);
-  assert.equal(4, responseHeader.extrasLength);
-  assert.equal(3, responseHeader.dataType);
-  assert.equal(1, responseHeader.status);
-  assert.equal(9, responseHeader.totalBodyLength);
-  assert.equal(0, responseHeader.opaque);
-  assert.equal(new Buffer([0x0a, 0, 0, 0, 0, 0, 0, 0]).toString(), responseHeader.cas);
-}
+  t.equal(0x81, responseHeader.magic);
+  t.equal(1, responseHeader.opcode);
+  t.equal(0x0700, responseHeader.keyLength);
+  t.equal(4, responseHeader.extrasLength);
+  t.equal(3, responseHeader.dataType);
+  t.equal(1, responseHeader.status);
+  t.equal(9, responseHeader.totalBodyLength);
+  t.equal(0, responseHeader.opaque);
+  t.equal(new Buffer([0x0a, 0, 0, 0, 0, 0, 0, 0]).toString(), responseHeader.cas.toString());
+  t.end();
+});
 
-exports.testDumpHeader = function(be, assert) {
-  responseHeader = {
+test('DumpHeader', function(t) {
+  var responseHeader = {
     magic: 0x81,
     opcode: 1,
     keyLength: 0x700,
@@ -25,13 +27,14 @@ exports.testDumpHeader = function(be, assert) {
     totalBodyLength: 9,
     opaque: 0,
     cas: new Buffer([0x0a, 0, 0, 0, 0, 0, 0, 0])
-  }
-  expected = new Buffer([0x81, 1, 7, 0, 4, 0, 0, 1, 0, 0, 0, 9, 0, 0, 0, 0, 0x0a, 0, 0, 0, 0, 0, 0, 0]);
-  assert.equal(header.toBuffer(responseHeader).toString(), expected.toString());
-}
+  };
+  var expected = new Buffer([0x81, 1, 7, 0, 4, 0, 0, 1, 0, 0, 0, 9, 0, 0, 0, 0, 0x0a, 0, 0, 0, 0, 0, 0, 0]);
+  t.equal(header.toBuffer(responseHeader).toString(), expected.toString());
+  t.end();
+});
 
-exports.testDumpHeaderNoCas = function(be, assert) {
-  responseHeader = {
+test('DumpHeaderNoCas', function(t) {
+  var responseHeader = {
     magic: 0x81,
     opcode: 0,
     keyLength: 0x0,
@@ -40,8 +43,9 @@ exports.testDumpHeaderNoCas = function(be, assert) {
     status: 0,
     totalBodyLength: 0,
     opaque: 0
-  }
-  expected = new Buffer([0x81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
-  assert.equal(header.toBuffer(responseHeader).toString(), expected.toString());
-}
+  };
+  var expected = new Buffer([0x81, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+  t.equal(header.toBuffer(responseHeader).toString(), expected.toString());
+  t.end();
+});
 

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -1,73 +1,75 @@
-var errors = require('protocol').errors;
-var MemJS = require('memjs');
-var events = require('events');
+var test = require('tap').test;
+var MemJS = require('../');
 var makeRequestBuffer = require('../lib/memjs/utils').makeRequestBuffer;
 
-exports.testAuthListMechanisms = function(beforeExit, assert) {
+test('AuthListMechanisms', function(t) {
   var expectedBuf = makeRequestBuffer(0x20, '', '', '');
-  var dummySocket =
-    { write: function(buf) {
-        assert.equal(expectedBuf.toString(), buf.toString());
-      }
-    };
+  var dummySocket = {
+    write: function(buf) {
+      t.equal(expectedBuf.toString(), buf.toString());
+    }
+  };
   var opts = {username: 'user1', password: 'password'};
   var server = new MemJS.Server('test.example.com', 11211, opts);
   server._socket = dummySocket;
   server.listSasl();
-}
+  t.end();
+});
 
-exports.testAuthenticate = function(beforeExit, assert) {
-  var expectedBuf = makeRequestBuffer(0x21, 'PLAIN', '',
-        '\0user1\0password');
-  var dummySocket =
-    { write: function(buf) {
-        assert.equal(expectedBuf.toString(), buf.toString());
-      }
-    };
-  var server = new MemJS.Server('test.example.com', 11211,
-                                'user1', 'password', {});
+test('Authenticate', function(t) {
+  var expectedBuf = makeRequestBuffer(0x21, 'PLAIN', '', '\0user1\0password');
+  var dummySocket = {
+    write: function(buf) {
+      t.equal(expectedBuf.toString(), buf.toString());
+    }
+  };
+  var server = new MemJS.Server('test.example.com', 11211, 'user1', 'password', {});
   server._socket = dummySocket;
   server.saslAuth();
-}
+  t.end();
+});
 
-exports.testSetSaslCredentials = function(beforeExit, assert) {
-  var server = new MemJS.Server('test.example.com', 11211, undefined,
+test('SetSaslCredentials', function(t) {
+  var server;
+  server = new MemJS.Server('test.example.com', 11211, undefined,
       undefined, {username: 'user1', password: 'password'});
-  assert.equal('user1', server.username);
-  assert.equal('password', server.password);
+  t.equal('user1', server.username);
+  t.equal('password', server.password);
 
-  var server = new MemJS.Server('test.example.com', 11211, 'user2',
+  server = new MemJS.Server('test.example.com', 11211, 'user2',
       'password2', {username: 'user1', password: 'password'});
-  assert.equal('user2', server.username);
-  assert.equal('password2', server.password);
+  t.equal('user2', server.username);
+  t.equal('password2', server.password);
 
-  var server = new MemJS.Server('test.example.com', 11211);
-  assert.equal(process.env.MEMCACHIER_USERNAME ||
+  server = new MemJS.Server('test.example.com', 11211);
+  t.equal(process.env.MEMCACHIER_USERNAME ||
                 process.env.MEMCACHE_USERNAME, server.username);
-  assert.equal(process.env.MEMCACHIER_PASSWORD ||
+  t.equal(process.env.MEMCACHIER_PASSWORD ||
                 process.env.MEMCACHE_PASSWORD, server.password);
-}
+  t.end();
+});
 
-exports.testResponseCallbackOrdering = function(beforeExit, assert) {
+test('ResponseCallbackOrdering', function(t) {
   var server = new MemJS.Server();
   var callbacksCalled = 0;
 
   server.onResponse(1, function() {
-    assert.equal(0, callbacksCalled);
+    t.equal(0, callbacksCalled);
     callbacksCalled += 1;
   });
   server.respond({header: {opaque: 1}});
 
   server.onResponse(2, function() {
-    assert.equal(1, callbacksCalled);
+    t.equal(1, callbacksCalled);
     callbacksCalled += 1;
   });
 
   server.onResponse(3, function() {
-    assert.equal(2, callbacksCalled);
+    t.equal(2, callbacksCalled);
     callbacksCalled += 1;
   });
 
   server.respond({header: {opaque: 2}});
   server.respond({header: {opaque: 3}});
-}
+  t.end();
+});

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -1,45 +1,50 @@
-utils = require('../lib/memjs/utils')
+var test = require('tap').test;
+var utils = require('../lib/memjs/utils');
 
-exports.testMergePresereParameter = function(beforeExit, assert) {
+test('MergePresereParameter', function(t) {
   var result = utils.merge({}, { retries: 2 });
-  assert.equal(2, result.retries);
-}
+  t.equal(2, result.retries);
+  t.end();
+});
 
-exports.testMergePresereParameterWhenZero = function(beforeExit, assert) {
+test('MergePresereParameterWhenZero', function(t) {
   var result = utils.merge({ retries: 0 }, { retries: 2 });
-  assert.equal(0, result.retries);
-}
+  t.equal(0, result.retries);
+  t.end();
+});
 
-exports.testMergeDontPresereParameterWhenUndefinedOrNull =
-  function(beforeExit, assert) {
-    var result = utils.merge({ retries: undefined }, { retries: 2 });
-    assert.equal(2, result.retries);
+test('MergeDontPresereParameterWhenUndefinedOrNull', function(t) {
+  var result = utils.merge({ retries: undefined }, { retries: 2 });
+  t.equal(2, result.retries);
 
-    var result2 = utils.merge({ retries: null }, { retries: 2 });
-    assert.equal(2, result2.retries);
-  }
+  var result2 = utils.merge({ retries: null }, { retries: 2 });
+  t.equal(2, result2.retries);
+  t.end();
+});
 
-exports.testMakeAmountInitialAndExpiration = function(beforeExit, assert) {
-    var extras, buf, fixture;
-    extras = utils.makeAmountInitialAndExpiration(1, 1, 1);
-    fixture = new Buffer('0000000000000001000000000000000100000001', 'hex');
-    assert.equal(20, extras.length);
-    assert.equal(fixture.toString('hex'), extras.toString('hex'));
-    buf = new Buffer(extras);
-    assert.equal(20, buf.length);
-    assert.equal(fixture.toString('hex'), buf.toString('hex'));
+test('MakeAmountInitialAndExpiration', function(t) {
+  var extras, buf, fixture;
+  extras = utils.makeAmountInitialAndExpiration(1, 1, 1);
+  fixture = new Buffer('0000000000000001000000000000000100000001', 'hex');
+  t.equal(20, extras.length);
+  t.equal(fixture.toString('hex'), extras.toString('hex'));
+  buf = new Buffer(extras);
+  t.equal(20, buf.length);
+  t.equal(fixture.toString('hex'), buf.toString('hex'));
 
-    extras = utils.makeAmountInitialAndExpiration(255, 1, 1);
-    fixture = new Buffer('00000000000000ff000000000000000100000001', 'hex');
-    assert.equal(20, extras.length);
-    assert.equal(fixture.toString('hex'), extras.toString('hex'));
-    buf = new Buffer(extras);
-    assert.equal(20, buf.length);
-    assert.equal(fixture.toString('hex'), buf.toString('hex'));
-}
+  extras = utils.makeAmountInitialAndExpiration(255, 1, 1);
+  fixture = new Buffer('00000000000000ff000000000000000100000001', 'hex');
+  t.equal(20, extras.length);
+  t.equal(fixture.toString('hex'), extras.toString('hex'));
+  buf = new Buffer(extras);
+  t.equal(20, buf.length);
+  t.equal(fixture.toString('hex'), buf.toString('hex'));
+  t.end();
+});
 
-exports.testMakeRequestBufferExtrasLength = function(beforeExit, assert) {
-    extras = utils.makeAmountInitialAndExpiration(255, 1, 1);
-    var buf = utils.makeRequestBuffer(0, 'test', extras, 1, 0);
-    assert.equal(20, buf[4]);
-}
+exports.testMakeRequestBufferExtrasLength = function(t) {
+  var extras = utils.makeAmountInitialAndExpiration(255, 1, 1);
+  var buf = utils.makeRequestBuffer(0, 'test', extras, 1, 0);
+  t.equal(20, buf[4]);
+  t.end();
+};


### PR DESCRIPTION
Switches the test runner form expresso to node-tape & lints the tests. Also make it possible to track code coverage! So running `./node_modules/.bin/tap --cov ./test/*.js` tells us;
```
--------------|----------|----------|----------|----------|----------------|
File          |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
--------------|----------|----------|----------|----------|----------------|
 memjs/       |    70.09 |    57.55 |    69.23 |    70.09 |                |
  header.js   |    95.24 |       90 |      100 |    95.24 |              3 |
  memjs.js    |    72.88 |    59.86 |    72.22 |    72.88 |... 467,480,481 |
  protocol.js |      100 |      100 |      100 |      100 |                |
  server.js   |    55.24 |    44.74 |    52.63 |    55.24 |... 132,146,150 |
  utils.js    |    68.12 |       50 |     87.5 |    68.12 |... 104,105,107 |
--------------|----------|----------|----------|----------|----------------|
All files     |    70.09 |    57.55 |    69.23 |    70.09 |                |
--------------|----------|----------|----------|----------|----------------|
```

@alevy there are a couple strange things I ran into while converting this. I'll call them out in comments below.