### PR TITLE
Switch to new argument scheme with options dictionary

### DIFF
--- a/lib/memjs/memjs.js
+++ b/lib/memjs/memjs.js
@@ -32,7 +32,7 @@ var Client = function(servers, options) {
 // * `expires` - the default expiration in seconds to use (default 0 - never
 // expire). If `expires` is greater than 30 days (60 x 60 x 24 x 30), it is
 // treated as a UNIX time (number of seconds since January 1, 1970).
-// * `logger` - a logger object that responds to
+// * `logger` - a logger object that responds to `log(string)` method calls.
 // * `failover` - whether to failover to next server. Defaults to false.
 // * `failoverTime` - how much to wait until retring a failed server. Default
 //                    is 60 seconds.
@@ -66,9 +66,9 @@ Client.create = function(serversStr, options) {
 };
 
 // Chooses the server to talk to by hashing the given key.
-// TODO(alevy): should use consistent hashing and/or allow swapping hashing
-// mechanisms
 Client.prototype.server = function(key) {
+  // TODO(alevy): should use consistent hashing and/or allow swapping hashing
+  // mechanisms
   var origIdx = hashCode(key) % this.servers.length;
   var idx = origIdx;
   var serv = this.servers[idx];
@@ -100,17 +100,18 @@ Client.prototype.server = function(key) {
 
 // GET
 //
-// Fetches the value at the given key with callback signature:
+// Retrieves the value at the given key in memcache.
+//
+// The callback signature is:
 //
 //     callback(err, value, flags)
 //
-// _value_ and _flags_ are both `Buffer`s.
-// If the key is not found, the callback is invoked
-// with null for both arguments and no error.
+// _value_ and _flags_ are both `Buffer`s. If the key is not found, the
+// callback is invoked with null for both arguments and no error.
 Client.prototype.get = function(key, callback) {
+  var logger = this.options.logger;
   this.seq++;
   var request = makeRequestBuffer(0, key, '', '', this.seq);
-  var logger = this.options.logger;
   this.perform(key, request, function(err, response) {
     if (err) {
       if (callback) { callback(err, null, null); }
@@ -133,17 +134,32 @@ Client.prototype.get = function(key, callback) {
 
 // SET
 //
-// Sets the given _key_ and _value_ in memcache. The _expires_ argument (passed
-// in last, after the callback) overrides the default expiration (see
-// `Client.create`). The callback signature is:
+// Sets the given _key_ and _value_ in memcache.
+//
+// The options dictionary takes:
+// * _expires_: overrides the default expiration (see `Client.create`) for this
+//              particular key-value pair.
+//
+// The callback signature is:
 //
 //     callback(err, success)
-Client.prototype.set = function(key, value, callback, expires) {
-  var extras = Buffer.concat([new Buffer('00000000', 'hex'),
-                              makeExpiration(expires || this.options.expires)]);
-  this.seq++;
-  var request = makeRequestBuffer(1, key, extras, value, this.seq);
+Client.prototype.set = function(key, value, options, callback) {
   var logger = this.options.logger;
+  var expires;
+  if (typeof options === 'function') {
+    // OLD: function(key, value, callback, expires)
+    logger.log('MemJS SET: using deprecated call - arguments have changed');
+    expires = callback;
+    callback = options;
+  } else if (options) {
+    expires = options.expires;
+  }
+
+  // TODO: support flags, support version (CAS)
+  this.seq++;
+  var expiration = makeExpiration(expires || this.options.expires);
+  var extras = Buffer.concat([new Buffer('00000000', 'hex'), expiration]);
+  var request = makeRequestBuffer(1, key, extras, value, this.seq);
   this.perform(key, request, function(err, response) {
     if (err) {
       if (callback) { callback(err, null); }
@@ -164,16 +180,32 @@ Client.prototype.set = function(key, value, callback, expires) {
 // ADD
 //
 // Adds the given _key_ and _value_ to memcache. The operation only succeeds
-// if the key is not already set. The _expires_ argument (passed
-// in last, after the callback) overrides the default expiration (see
-// `Client.create`). The callback signature is:
+// if the key is not already set.
+//
+// The options dictionary takes:
+// * _expires_: overrides the default expiration (see `Client.create`) for this
+//              particular key-value pair.
+//
+// The callback signature is:
 //
 //     callback(err, success)
-Client.prototype.add = function(key, value, callback, expires) {
-  var extras = Buffer.concat([new Buffer('00000000', 'hex'), makeExpiration(expires || this.options.expires)]);
-  this.seq++;
-  var request = makeRequestBuffer(2, key, extras, value, this.seq);
+Client.prototype.add = function(key, value, options, callback) {
   var logger = this.options.logger;
+  var expires;
+  if (typeof options === 'function') {
+    // OLD: function(key, value, callback, expires)
+    logger.log('MemJS ADD: using deprecated call - arguments have changed');
+    expires = callback;
+    callback = options;
+  } else if (options) {
+    expires = options.expires;
+  }
+
+  // TODO: support flags, support version (CAS)
+  this.seq++;
+  var expiration = makeExpiration(expires || this.options.expires);
+  var extras = Buffer.concat([new Buffer('00000000', 'hex'), expiration]);
+  var request = makeRequestBuffer(2, key, extras, value, this.seq);
   this.perform(key, request, function(err, response) {
     if (err) {
       if (callback) { callback(err, null, null); }
@@ -197,16 +229,32 @@ Client.prototype.add = function(key, value, callback, expires) {
 // REPLACE
 //
 // Replaces the given _key_ and _value_ to memcache. The operation only succeeds
-// if the key is already present. The _expires_ argument (passed
-// in last, after the callback) overrides the default expiration (see
-// `Client.create`). The callback signature is:
+// if the key is already present.
+//
+// The options dictionary takes:
+// * _expires_: overrides the default expiration (see `Client.create`) for this
+//              particular key-value pair.
+//
+// The callback signature is:
 //
 //     callback(err, success)
-Client.prototype.replace = function(key, value, callback, expires) {
-  var extras = Buffer.concat([new Buffer('00000000', 'hex'), makeExpiration(expires || this.options.expires)]);
-  this.seq++;
-  var request = makeRequestBuffer(3, key, extras, value, this.seq);
+Client.prototype.replace = function(key, value, options, callback) {
   var logger = this.options.logger;
+  var expires;
+  if (typeof options === 'function') {
+    // OLD: function(key, value, callback, expires)
+    logger.log('MemJS REPLACE: using deprecated call - arguments have changed');
+    expires = callback;
+    callback = options;
+  } else if (options) {
+    expires = options.expires;
+  }
+
+  // TODO: support flags, support version (CAS)
+  this.seq++;
+  var expiration = makeExpiration(expires || this.options.expires);
+  var extras = Buffer.concat([new Buffer('00000000', 'hex'), expiration]);
+  var request = makeRequestBuffer(3, key, extras, value, this.seq);
   this.perform(key, request, function(err, response) {
     if (err) {
       if (callback) { callback(err, null, null); }
@@ -230,13 +278,16 @@ Client.prototype.replace = function(key, value, callback, expires) {
 // DELETE
 //
 // Deletes the given _key_ from memcache. The operation only succeeds
-// if the key is already present. The callback signature is:
+// if the key is already present.
+//
+// The callback signature is:
 //
 //     callback(err, success)
 Client.prototype.delete = function(key, callback) {
+  // TODO: Support version (CAS)
+  var logger = this.options.logger;
   this.seq++;
   var request = makeRequestBuffer(4, key, '', '', this.seq);
-  var logger = this.options.logger;
   this.perform(key, request, function(err, response) {
     if (err) {
       if (callback) { callback(err, null, null); }
@@ -259,18 +310,37 @@ Client.prototype.delete = function(key, callback) {
 
 // INCREMENT
 //
-// Increments the given _key_ in memcache. If the key is not
-// present, defaults to _initial_ if supplied, or `0` otherwise. The _expires_
-// argument (passed in last, after the callback) overrides the
-// default expiration (see `Client.create`). The callback signature is:
+// Increments the given _key_ in memcache.
+//
+// The options dictionary takes:
+// * _initial_: the value for the key if not already present, defaults to 0.
+// * _expires_: overrides the default expiration (see `Client.create`) for this
+//              particular key-value pair.
+//
+// The callback signature is:
 //
 //     callback(err, success, value)
-Client.prototype.increment = function(key, amount, callback, expires, initial) {
-  var extras = makeAmountInitialAndExpiration(amount, (initial || 0), (expires || this.options.expires));
-  this.seq++;
-  var request = makeRequestBuffer(5, key, extras, '', this.seq);
-
+Client.prototype.increment = function(key, amount, options, callback) {
   var logger = this.options.logger;
+  var initial;
+  var expires;
+  if (typeof options === 'function') {
+    // OLD: function(key, amount, callback, expires, initial)
+    logger.log('MemJS INCREMENT: using deprecated call - arguments have changed');
+    initial = arguments[4];
+    expires = callback;
+    callback = options;
+  } else if (options) {
+    initial = options.initial;
+    expires = options.expires;
+  }
+
+  // TODO: support version (CAS)
+  this.seq++;
+  initial = initial || 0;
+  expires = expires || this.options.expires;
+  var extras = makeAmountInitialAndExpiration(amount, initial, expires);
+  var request = makeRequestBuffer(5, key, extras, '', this.seq);
   this.perform(key, request, function(err, response) {
     if (err) {
       if (callback) { callback(err, null); }
@@ -284,25 +354,43 @@ Client.prototype.increment = function(key, amount, callback, expires, initial) {
     default:
       var errorMessage = 'MemJS INCREMENT: ' + errors[response.header.status];
       logger.log(errorMessage);
-      if (callback) { callback(new Error(errorMessage), null); }
+      if (callback) { callback(new Error(errorMessage), null, null); }
     }
   });
 };
 
 // DECREMENT
 //
-// Decrements the given _key_ in memcache. If the key is not
-// present, defaults to _initial_ if supplied, or `0` otherwise. The _expires_
-// argument (passed in last, after the callback) overrides the
-// default expiration (see `Client.create`). The callback signature is:
+// Decrements the given _key_ in memcache.
+//
+// The options dictionary takes:
+// * _initial_: the value for the key if not already present, defaults to 0.
+// * _expires_: overrides the default expiration (see `Client.create`) for this
+//              particular key-value pair.
+//
+// The callback signature is:
 //
 //     callback(err, success, value)
-Client.prototype.decrement = function(key, amount, callback, expires, initial) {
-  var extras = makeAmountInitialAndExpiration(amount, (initial || 0), (expires || this.options.expires));
-  this.seq++;
-  var request = makeRequestBuffer(6, key, extras, '', this.seq);
-
+Client.prototype.decrement = function(key, amount, options, callback) {
+  // TODO: support version (CAS)
   var logger = this.options.logger;
+  var initial;
+  var expires;
+  if (typeof options === 'function') {
+    // OLD: function(key, amount, callback, expires, initial)
+    logger.log('MemJS DECREMENT: using deprecated call - arguments have changed');
+    initial = arguments[4];
+    expires = callback;
+    callback = options;
+  } else if (options) {
+    initial = options.initial;
+    expires = options.expires;
+  }
+  this.seq++;
+  initial = initial || 0;
+  expires = expires || this.options.expires;
+  var extras = makeAmountInitialAndExpiration(amount, initial, expires);
+  var request = makeRequestBuffer(6, key, extras, '', this.seq);
   this.perform(key, request, function(err, response) {
     if (err) {
       if (callback) { callback(err, null); }
@@ -316,7 +404,7 @@ Client.prototype.decrement = function(key, amount, callback, expires, initial) {
     default:
       var errorMessage = 'MemJS DECREMENT: ' + errors[response.header.status];
       logger.log(errorMessage);
-      if (callback) { callback(new Error(errorMessage), null); }
+      if (callback) { callback(new Error(errorMessage), null, null); }
     }
   });
 };
@@ -329,10 +417,10 @@ Client.prototype.decrement = function(key, amount, callback, expires, initial) {
 //
 //     callback(err, success)
 Client.prototype.append = function(key, value, callback) {
+  // TODO: support version (CAS)
+  var logger = this.options.logger;
   this.seq++;
   var request = makeRequestBuffer(0x0E, key, '', value, this.seq);
-
-  var logger = this.options.logger;
   this.perform(key, request, function(err, response) {
     if (err) {
       if (callback) { callback(err, null); }
@@ -361,10 +449,10 @@ Client.prototype.append = function(key, value, callback) {
 //
 //     callback(err, success)
 Client.prototype.prepend = function(key, value, callback) {
+  // TODO: support version (CAS)
+  var logger = this.options.logger;
   this.seq++;
   var request = makeRequestBuffer(0x0E, key, '', value, this.seq);
-
-  var logger = this.options.logger;
   this.perform(key, request, function(err, response) {
     if (err) {
       if (callback) { callback(err, null); }
@@ -393,11 +481,11 @@ Client.prototype.prepend = function(key, value, callback) {
 //
 //     callback(err, success)
 Client.prototype.touch = function(key, expires, callback) {
+  // TODO: support version (CAS)
+  var logger = this.options.logger;
   this.seq++;
   var extras = makeExpiration(expires || this.options.expires);
   var request = makeRequestBuffer(0x1C, key, extras, '', this.seq);
-
-  var logger = this.options.logger;
   this.perform(key, request, function(err, response) {
     if (err) {
       if (callback) { callback(err, null); }
@@ -428,6 +516,7 @@ Client.prototype.touch = function(key, expires, callback) {
 // of no errors). _results_ is a dictionary mapping `"hostname:port"` to either
 // `true` (if the operation was successful), or an error.
 Client.prototype.flush = function(callback) {
+  // TODO: support expiration
   this.seq++;
   var request = makeRequestBuffer(0x08, '', '', '', this.seq);
   var count   = this.servers.length;
@@ -469,9 +558,9 @@ Client.prototype.flush = function(callback) {
 // _server_ is the `"hostname:port"` of the server, and _stats_ is a dictionary
 // mapping the stat name to the value of the statistic as a string.
 Client.prototype.statsWithKey = function(key, callback) {
+  var logger = this.options.logger;
   this.seq++;
   var request = makeRequestBuffer(0x10, key, '', '', this.seq);
-  var logger = this.options.logger;
   var i;
 
   var handleStats = function(seq, serv) {
@@ -528,7 +617,7 @@ Client.prototype.stats = function(callback) {
 //
 // Reset the statistics each server is keeping back to zero. This doesn't clear
 // stats such as item count, but temporary stats such as total number of
-// connections over time.T
+// connections over time.
 //
 // The callback is invoked **ONCE PER SERVER** and has the signature:
 //
@@ -582,7 +671,9 @@ Client.prototype.close = function() {
 // Perform a generic single response operation (get, set etc) on a server
 // serv: the server to perform the operation on
 // request: a buffer containing the request
-// callback
+// callback: a callback invoked when a response is received or the request
+//           fails
+// retries: number of times to retry request on failure
 Client.prototype.perform = function(key, request, callback, retries) {
   var _this = this;
   var seq = this.seq;

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -56,6 +56,26 @@ test('SetSuccessful', function(t) {
   };
 
   var client = new MemJS.Client([dummyServer]);
+  client.set('hello', 'world', {}, function(err, val) {
+    t.equal(true, val);
+    t.equal(null, err);
+    t.equal(1, n, 'Ensure set is called');
+    t.end();
+  });
+});
+
+test('SetDeprecated', function(t) {
+  var n = 0;
+  var dummyServer = new MemJS.Server();
+  dummyServer.write = function(requestBuf) {
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal('hello', request.key.toString());
+    t.equal('world', request.val.toString());
+    n += 1;
+    dummyServer.respond({header: {status: 0, opaque: request.header.opaque}});
+  };
+
+  var client = new MemJS.Client([dummyServer]);
   client.set('hello', 'world', function(err, val) {
     t.equal(true, val);
     t.equal(null, err);
@@ -77,7 +97,7 @@ test('SetWithExpiration', function(t) {
   };
 
   var client = new MemJS.Client([dummyServer], {expires: 1024});
-  client.set('hello', 'world', function(err, val) {
+  client.set('hello', 'world', {}, function(err, val) {
     t.equal(null, err);
     t.equal(true, val);
     t.equal(1, n, 'Ensure set is called');
@@ -97,7 +117,7 @@ test('SetUnsuccessful', function(t) {
   };
 
   var client = new MemJS.Client([dummyServer]);
-  client.set('hello', 'world', function(err, val) {
+  client.set('hello', 'world', {}, function(err, val) {
     t.equal(null, val);
     t.equal('MemJS SET: ' + errors[3], err.message);
     t.equal(1, n, 'Ensure set is called');
@@ -117,7 +137,7 @@ test('SetError', function(t) {
   };
 
   var client = new MemJS.Client([dummyServer]);
-  client.set('hello', 'world', function(err, val) {
+  client.set('hello', 'world', {}, function(err, val) {
     t.notEqual(null, err);
     t.equal('This is an expected error.', err.message);
     t.equal(null, val);
@@ -140,7 +160,7 @@ test('SetError', function(t) {
   };
 
   var client = new MemJS.Client([dummyServer], {retries: 2});
-  client.set('hello', 'world', function(err /*, val */) {
+  client.set('hello', 'world', {}, function(err /*, val */) {
     t.equal(2, n, 'Ensure set is retried once');
     t.ok(err, 'Ensure callback called with error');
     t.equal('This is an expected error.', err.message);
@@ -161,14 +181,14 @@ test('SetErrorConcurrent', function(t) {
   };
 
   var client = new MemJS.Client([dummyServer], {retries: 2});
-  client.set('hello', 'world', function(err /*, val */) {
+  client.set('hello', 'world', {}, function(err /*, val */) {
     t.ok(err, 'Ensure callback called with error');
     t.equal('This is an expected error.', err.message);
     callbn1 += 1;
     done();
   });
 
-  client.set('foo', 'bar', function(err /*, val */) {
+  client.set('foo', 'bar', {}, function(err /*, val */) {
     t.ok(err, 'Ensure callback called with error');
     t.equal('This is an expected error.', err.message);
     callbn2 += 1;
@@ -205,7 +225,7 @@ test('SetUnicode', function(t) {
   };
 
   var client = new MemJS.Client([dummyServer]);
-  client.set('hello', 'éééoào', function(err, val) {
+  client.set('hello', 'éééoào', {}, function(err, val) {
     t.equal(true, val);
     t.equal(1, n, 'Ensure set is called');
     t.end();
@@ -213,6 +233,27 @@ test('SetUnicode', function(t) {
 });
 
 test('AddSuccessful', function(t) {
+  var n = 0;
+  var dummyServer = new MemJS.Server();
+  dummyServer.write = function(requestBuf) {
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal('hello', request.key.toString());
+    t.equal('world', request.val.toString());
+    t.equal('0000000000000400', request.extras.toString('hex'));
+    n += 1;
+    dummyServer.respond({header: {status: 0, opaque: request.header.opaque}});
+  };
+
+  var client = new MemJS.Client([dummyServer], {expires: 1024});
+  client.add('hello', 'world', {}, function(err, val) {
+    t.equal(null, err);
+    t.equal(true, val);
+    t.equal(1, n, 'Ensure add is called');
+    t.end();
+  });
+});
+
+test('AddDeprecated', function(t) {
   var n = 0;
   var dummyServer = new MemJS.Server();
   dummyServer.write = function(requestBuf) {
@@ -245,7 +286,7 @@ test('AddKeyExists', function(t) {
   };
 
   var client = new MemJS.Client([dummyServer]);
-  client.add('hello', 'world', function(err, val) {
+  client.add('hello', 'world', {}, function(err, val) {
     t.equal(null, err);
     t.equal(false, val);
     t.equal(1, n, 'Ensure add is called');
@@ -254,6 +295,27 @@ test('AddKeyExists', function(t) {
 });
 
 test('ReplaceSuccessful', function(t) {
+  var n = 0;
+  var dummyServer = new MemJS.Server();
+  dummyServer.write = function(requestBuf) {
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal('hello', request.key.toString());
+    t.equal('world', request.val.toString());
+    t.equal('\0\0\0\0\0\0\4\0', request.extras.toString());
+    n += 1;
+    dummyServer.respond({header: {status: 0, opaque: request.header.opaque}});
+  };
+
+  var client = new MemJS.Client([dummyServer], {expires: 1024});
+  client.replace('hello', 'world', {}, function(err, val) {
+    t.equal(null, err);
+    t.equal(true, val);
+    t.equal(1, n, 'Ensure replace is called');
+    t.end();
+  });
+});
+
+test('ReplaceDeprecated', function(t) {
   var n = 0;
   var dummyServer = new MemJS.Server();
   dummyServer.write = function(requestBuf) {
@@ -286,7 +348,7 @@ test('ReplaceKeyDNE', function(t) {
   };
 
   var client = new MemJS.Client([dummyServer]);
-  client.replace('hello', 'world', function(err, val) {
+  client.replace('hello', 'world', {}, function(err, val) {
     t.equal(null, err);
     t.equal(false, val);
     t.equal(1, n, 'Ensure replace is called');
@@ -409,6 +471,60 @@ test('IncrementSuccessful', function(t) {
   };
 
   var client = new MemJS.Client([dummyServer]);
+  client.increment('number-increment-test', 5, {}, function(err, success, val){
+    callbn += 1;
+    t.equal(true, success);
+    t.equal(6, val);
+    t.equal(null, err);
+    done();
+  });
+
+  client.increment('number-increment-test', 5, {initial: 3}, function(err, success, val) {
+    callbn += 1;
+    t.equal(true, success);
+    t.equal(6, val);
+    t.equal(null, err);
+    done();
+  });
+
+  var done =(function() {
+    var called = 0;
+    return function() {
+      called += 1;
+      if (called < 2) return; 
+      t.equal(2, n, 'Ensure increment is called twice');
+      t.equal(2, callbn, 'Ensure callback is called twice');
+      t.end();
+    };
+  })();
+});
+
+test('IncrementDeprecated', function(t) {
+  var n = 0;
+  var callbn = 0;
+  var dummyServer = new MemJS.Server();
+
+  var expectedExtras = [
+    '\0\0\0\0\0\0\0\5\0\0\0\0\0\0\0\0\0\0\0\0',
+    '\0\0\0\0\0\0\0\5\0\0\0\0\0\0\0\3\0\0\0\0'
+  ];
+
+  dummyServer.write = function(requestBuf) {
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal(5, request.header.opcode);
+    t.equal('number-increment-test', request.key.toString());
+    t.equal('', request.val.toString());
+    t.equal(expectedExtras[n], request.extras.toString());
+    n += 1;
+    process.nextTick(function() {
+      var value = new Buffer(8);
+      value.writeUInt32BE(request.header.opcode + 1, 4);
+      value.writeUInt32BE(0, 0);
+      dummyServer.respond({header: {status: 0, opaque: request.header.opaque}, val: value});
+    });
+  };
+
+  var client = new MemJS.Client([dummyServer]);
   client.increment('number-increment-test', 5, function(err, success, val){
     callbn += 1;
     t.equal(true, success);
@@ -457,7 +573,36 @@ test('DecrementSuccessful', function(t) {
   };
 
   var client = new MemJS.Client([dummyServer]);
-  client.decrement('number-decrement-test', 5, function(err, success, val){
+  client.decrement('number-decrement-test', 5, {}, function(err, success, val) {
+    t.equal(true, success);
+    t.equal(6, val);
+    t.equal(null, err);
+    t.equal(1, n, 'Ensure decr is called');
+    t.end();
+  });
+});
+
+test('DecrementDeprecated', function(t) {
+  var n = 0;
+  var dummyServer = new MemJS.Server();
+  dummyServer.write = function(requestBuf) {
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal(6, request.header.opcode);
+    t.equal('number-decrement-test', request.key.toString());
+    t.equal('', request.val.toString());
+    t.equal('\0\0\0\0\0\0\0\5\0\0\0\0\0\0\0\0\0\0\0\0',
+                 request.extras.toString());
+    n += 1;
+    process.nextTick(function() {
+      var value = new Buffer(8);
+      value.writeUInt32BE(request.header.opcode, 4);
+      value.writeUInt32BE(0, 0);
+      dummyServer.respond({header: {status: 0, opaque: request.header.opaque}, val: value});
+    });
+  };
+
+  var client = new MemJS.Client([dummyServer]);
+  client.decrement('number-decrement-test', 5, function(err, success, val) {
     t.equal(true, success);
     t.equal(6, val);
     t.equal(null, err);


### PR DESCRIPTION
We now declare methods generally as:

```
    function(key, value, options, callback)
```

Rather than adding each argument (generally unused) as trailing
arguments after callback. Callback is _always_ the last argument now.

To handle backwards compatability, we check the type of `options` and if
it is a function, we treat arguments as corresponding to the old
interface but issue a depreceated warning.

This fixes issue #53 and #50, making CAS also easier to support going
forward.
