### PR TITLE
Better authentication error handling

### DIFF
--- a/lib/memjs/server.js
+++ b/lib/memjs/server.js
@@ -62,7 +62,7 @@ Server.prototype.error = function(err) {
   this.errorCallbacks = {};
   this.timeoutSet = false;
   if (this._socket) {
-    this._socket.destroy(); 
+    this._socket.destroy();
     delete(this._socket);
   }
   var k;
@@ -99,7 +99,7 @@ Server.prototype.responseHandler = function(dataBuf) {
     if (response.header.opcode === 0x20) {
       this.saslAuth();
     } else if (response.header.status === 0x20) {
-      this.listSasl();
+      this.error('Memcached server authentication failed!');
     } else if (response.header.opcode === 0x21) {
       this.emit('authenticated');
     } else {
@@ -134,7 +134,7 @@ Server.prototype.sock = function(sasl, go) {
           self.connectCallbacks = [];
         }
       });
-      
+
       // setup response handler
       this.on('data', function(dataBuf) {
         self.responseHandler(dataBuf);

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -17,19 +17,14 @@ test('AuthListMechanisms', function(t) {
 
 
 test('ResponseHandler with authentication error', function(t) {
-  var dummySocket = {
-    write: function() {},
-    destroy: function() {}
-  };
-
-  var server = new MemJS.Server('localhost', 11211, 'test', 'test');
-  server._socket = dummySocket;
+  var server = new MemJS.Server('localhost', 11211);
 
   server.onError('test', function(err) {
     t.equal('Memcached server authentication failed!', err);
   });
 
-  // Simulate a memcached server response, with an authentication error (no SASL configured, wrong credentials, ...).
+  // Simulate a memcached server response, with an authentication error
+  // No SASL configured, wrong credentials, ...
   var responseBuf = makeRequestBuffer(0x21, '', '', '');
   // Override status
   // 0x20 = Authentication required / Not Successful

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -1,7 +1,6 @@
 var test = require('tap').test;
 var MemJS = require('../');
 var makeRequestBuffer = require('../lib/memjs/utils').makeRequestBuffer;
-var header = require('../lib/memjs/header');
 
 test('AuthListMechanisms', function(t) {
   var expectedBuf = makeRequestBuffer(0x20, '', '', '');
@@ -19,7 +18,7 @@ test('AuthListMechanisms', function(t) {
 
 test('ResponseHandler with authentication error', function(t) {
   var dummySocket = {
-    write: function(buf) {},
+    write: function() {},
     destroy: function() {}
   };
 
@@ -27,18 +26,18 @@ test('ResponseHandler with authentication error', function(t) {
   server._socket = dummySocket;
 
   server.onError('test', function(err) {
-    t.equal('Memcached server authentication failed!', err)
-  })
+    t.equal('Memcached server authentication failed!', err);
+  });
 
   // Simulate a memcached server response, with an authentication error (no SASL configured, wrong credentials, ...).
   var responseBuf = makeRequestBuffer(0x21, '', '', '');
   // Override status
   // 0x20 = Authentication required / Not Successful
-  responseBuf.writeUInt16BE(0x20, 6)
+  responseBuf.writeUInt16BE(0x20, 6);
 
   server.responseHandler(responseBuf);
 
-  t.end()
+  t.end();
 });
 
 test('Authenticate', function(t) {


### PR DESCRIPTION
Hi Amit,
I encountered an issue about the SASL authentication, if you make a mistake in the username/password or if the memcached server isn't configured properly (no user/password set).

I suggest this modification, otherwise, it creates an infinite loop : `listSasl()` is called, `responseHandler` is then called, and the status remains 0x20 so it calls `listSasl()` again, and so on.

Can you give me your feedback about this fix ?
Thanks
Cheers