### PR TITLE
Fixes set(...) not being backwards compatible on null callback.

### DIFF
--- a/lib/memjs/memjs.js
+++ b/lib/memjs/memjs.js
@@ -146,7 +146,7 @@ Client.prototype.get = function(key, callback) {
 Client.prototype.set = function(key, value, options, callback) {
   var logger = this.options.logger;
   var expires;
-  if (typeof options === 'function') {
+  if (typeof options === 'function' || typeof callback === 'number') {
     // OLD: function(key, value, callback, expires)
     logger.log('MemJS SET: using deprecated call - arguments have changed');
     expires = callback;


### PR DESCRIPTION
Clients still using the old argument ordering with a null or undefined callback are broken since the API determines old vs new usage using `typeof options` for which null is a valid case. This fix also detects the old API usage in the case that callback is the expiration interval.