### PR TITLE
Fix callback comparison so promises are returned

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ You can start using MemJS immediately from the node console:
     $ var client = memjs.Client.create()
     $ client.get('hello', function(err, val) { console.log(val); })
 
+If callbacks are not specified, the command calls return promises.
+
 ### Settings Values
 
 ``` javascript

--- a/lib/memjs/memjs.js
+++ b/lib/memjs/memjs.js
@@ -109,7 +109,7 @@ Client.prototype.server = function(key) {
 // _value_ and _flags_ are both `Buffer`s. If the key is not found, the
 // callback is invoked with null for both arguments and no error.
 Client.prototype.get = function(key, callback) {
-  if(typeof callback === undefined) {
+  if(callback === undefined) {
     var self = this;
     return new Promise(function(resolve, reject) { self.get(key, function(err, val) { err ? reject(err) : resolve(val); }); });
   }
@@ -148,7 +148,7 @@ Client.prototype.get = function(key, callback) {
 //
 //     callback(err, success)
 Client.prototype.set = function(key, value, options, callback) {
-  if(typeof callback === undefined) {     
+  if(callback === undefined) {     
     var self = this;     
     return new Promise(function(resolve, reject) { self.set(key, value, options, function(err, val) { err ? reject(err) : resolve(val); }); });
   }
@@ -200,7 +200,7 @@ Client.prototype.set = function(key, value, options, callback) {
 //
 //     callback(err, success)
 Client.prototype.add = function(key, value, options, callback) {
-  if(typeof callback === undefined) {     
+  if(callback === undefined) {     
     var self = this;     
     return new Promise(function(resolve, reject) { self.add(key, value, options, function(err, val) { err ? reject(err) : resolve(val); }); });
   }
@@ -255,7 +255,7 @@ Client.prototype.add = function(key, value, options, callback) {
 //
 //     callback(err, success)
 Client.prototype.replace = function(key, value, options, callback) {
-  if(typeof callback === undefined) {     
+  if(callback === undefined) {     
     var self = this;     
     return new Promise(function(resolve, reject) { self.replace(key, value, options, function(err, val) { err ? reject(err) : resolve(val); }); });
   }
@@ -306,7 +306,7 @@ Client.prototype.replace = function(key, value, options, callback) {
 //
 //     callback(err, success)
 Client.prototype.delete = function(key, callback) {
-  if(typeof callback === undefined) {     
+  if(callback === undefined) {     
     var self = this;     
     return new Promise(function(resolve, reject) { self.delete(key, function(err, val) { err ? reject(err) : resolve(val); }); });
   }
@@ -347,7 +347,7 @@ Client.prototype.delete = function(key, callback) {
 //
 //     callback(err, success, value)
 Client.prototype.increment = function(key, amount, options, callback) {
-  if(typeof callback === undefined) {     
+  if(callback === undefined) {     
     var self = this;     
     return new Promise(function(resolve, reject) { self.increment(key, amount, options, function(err, val) { err ? reject(err) : resolve(val); }); });
   }
@@ -404,7 +404,7 @@ Client.prototype.increment = function(key, amount, options, callback) {
 //
 //     callback(err, success, value)
 Client.prototype.decrement = function(key, amount, options, callback) {
-  if(typeof callback === undefined) {     
+  if(callback === undefined) {     
     var self = this;     
     return new Promise(function(resolve, reject) { self.decrement(key, amount, options, function(err, val) { err ? reject(err) : resolve(val); }); });
   }
@@ -457,7 +457,7 @@ Client.prototype.decrement = function(key, amount, options, callback) {
 //
 //     callback(err, success)
 Client.prototype.append = function(key, value, callback) {
-  if(typeof callback === undefined) {     
+  if(callback === undefined) {     
     var self = this;     
     return new Promise(function(resolve, reject) { self.append(key, value, function(err, val) { err ? reject(err) : resolve(val); }); });
   }
@@ -493,7 +493,7 @@ Client.prototype.append = function(key, value, callback) {
 //
 //     callback(err, success)
 Client.prototype.prepend = function(key, value, callback) {
-  if(typeof callback === undefined) {     
+  if(callback === undefined) {     
     var self = this;     
     return new Promise(function(resolve, reject) { self.prepend(key, value, function(err, val) { err ? reject(err) : resolve(val); }); });
   }
@@ -529,7 +529,7 @@ Client.prototype.prepend = function(key, value, callback) {
 //
 //     callback(err, success)
 Client.prototype.touch = function(key, expires, callback) {
-  if(typeof callback === undefined) {     
+  if(callback === undefined) {     
     var self = this;     
     return new Promise(function(resolve, reject) { self.touch(key, expires, function(err, val) { err ? reject(err) : resolve(val); }); });
   }
@@ -568,7 +568,7 @@ Client.prototype.touch = function(key, expires, callback) {
 // of no errors). _results_ is a dictionary mapping `"hostname:port"` to either
 // `true` (if the operation was successful), or an error.
 Client.prototype.flush = function(callback) {
-  if(typeof callback === undefined) {     
+  if(callback === undefined) {     
     var self = this;     
     return new Promise(function(resolve, reject) { self.flush(function(err, val) { err ? reject(err) : resolve(val); }); });
   }

--- a/lib/memjs/memjs.js
+++ b/lib/memjs/memjs.js
@@ -83,6 +83,15 @@ Client.prototype.server = function(key) {
   return serv;
 };
 
+// converts a call into a promise-returning one
+var promisify = function(command) {
+  return new Promise(function(resolve, reject) {
+    command(function(err, result) {
+      err ? reject(err) : resolve(result);
+    });
+  });
+};
+
 // ## Memcache Commands
 //
 // All commands return their results through a callback passed as the last
@@ -111,7 +120,11 @@ Client.prototype.server = function(key) {
 Client.prototype.get = function(key, callback) {
   if(callback === undefined) {
     var self = this;
-    return new Promise(function(resolve, reject) { self.get(key, function(err, val) { err ? reject(err) : resolve(val); }); });
+    return promisify(function(callback) {
+      self.get(key, function(err, value, flags) {
+        callback(err, {value: value, flags: flags});
+      });
+    });
   }
   var logger = this.options.logger;
   this.seq++;
@@ -148,9 +161,9 @@ Client.prototype.get = function(key, callback) {
 //
 //     callback(err, success)
 Client.prototype.set = function(key, value, options, callback) {
-  if(callback === undefined) {     
-    var self = this;     
-    return new Promise(function(resolve, reject) { self.set(key, value, options, function(err, val) { err ? reject(err) : resolve(val); }); });
+  if(callback === undefined && typeof options !== 'function') {
+    var self = this;
+    return promisify(function(callback) { self.set(key, value, options, function(err, success) { callback(err, success); }); });
   }
   var logger = this.options.logger;
   var expires;
@@ -200,9 +213,9 @@ Client.prototype.set = function(key, value, options, callback) {
 //
 //     callback(err, success)
 Client.prototype.add = function(key, value, options, callback) {
-  if(callback === undefined) {     
+  if(callback === undefined && options !== 'function') {     
     var self = this;     
-    return new Promise(function(resolve, reject) { self.add(key, value, options, function(err, val) { err ? reject(err) : resolve(val); }); });
+    return promisify(function(callback) { self.add(key, value, options, function(err, success) { callback(err, success); }); });
   }
   var logger = this.options.logger;
   var expires;
@@ -255,9 +268,9 @@ Client.prototype.add = function(key, value, options, callback) {
 //
 //     callback(err, success)
 Client.prototype.replace = function(key, value, options, callback) {
-  if(callback === undefined) {     
+  if(callback === undefined && options !== 'function') {     
     var self = this;     
-    return new Promise(function(resolve, reject) { self.replace(key, value, options, function(err, val) { err ? reject(err) : resolve(val); }); });
+    return promisify(function(callback) { self.replace(key, value, options, function(err, success) { callback(err, success); }); });
   }
   var logger = this.options.logger;
   var expires;
@@ -308,7 +321,7 @@ Client.prototype.replace = function(key, value, options, callback) {
 Client.prototype.delete = function(key, callback) {
   if(callback === undefined) {     
     var self = this;     
-    return new Promise(function(resolve, reject) { self.delete(key, function(err, val) { err ? reject(err) : resolve(val); }); });
+    return promisify(function(callback) { self.delete(key, function(err, success) { callback(err, success); }); });
   }
   // TODO: Support version (CAS)
   var logger = this.options.logger;
@@ -347,9 +360,13 @@ Client.prototype.delete = function(key, callback) {
 //
 //     callback(err, success, value)
 Client.prototype.increment = function(key, amount, options, callback) {
-  if(callback === undefined) {     
+  if(callback === undefined && options !== 'function') {     
     var self = this;     
-    return new Promise(function(resolve, reject) { self.increment(key, amount, options, function(err, val) { err ? reject(err) : resolve(val); }); });
+    return promisify(function(callback) {
+      self.increment(key, amount, options, function(err, success, value) {
+        callback(err, {success: success, value: value});
+      });
+    });
   }
   var logger = this.options.logger;
   var initial;
@@ -404,9 +421,13 @@ Client.prototype.increment = function(key, amount, options, callback) {
 //
 //     callback(err, success, value)
 Client.prototype.decrement = function(key, amount, options, callback) {
-  if(callback === undefined) {     
+  if(callback === undefined && options !== 'function') {     
     var self = this;     
-    return new Promise(function(resolve, reject) { self.decrement(key, amount, options, function(err, val) { err ? reject(err) : resolve(val); }); });
+    return promisify(function(callback) {
+      self.decrement(key, amount, options, function(err, success, value) {
+        callback(err, {success: success, value: value});
+      });
+    });
   }
   // TODO: support version (CAS)
   var logger = this.options.logger;
@@ -459,7 +480,7 @@ Client.prototype.decrement = function(key, amount, options, callback) {
 Client.prototype.append = function(key, value, callback) {
   if(callback === undefined) {     
     var self = this;     
-    return new Promise(function(resolve, reject) { self.append(key, value, function(err, val) { err ? reject(err) : resolve(val); }); });
+    return promisify(function(callback) { self.append(key, value, function(err, success) { callback(err, success); }); });
   }
   // TODO: support version (CAS)
   var logger = this.options.logger;
@@ -495,7 +516,7 @@ Client.prototype.append = function(key, value, callback) {
 Client.prototype.prepend = function(key, value, callback) {
   if(callback === undefined) {     
     var self = this;     
-    return new Promise(function(resolve, reject) { self.prepend(key, value, function(err, val) { err ? reject(err) : resolve(val); }); });
+    return promisify(function(callback) { self.prepend(key, value, function(err, success) { callback(err, success); }); });
   }
   // TODO: support version (CAS)
   var logger = this.options.logger;
@@ -531,7 +552,7 @@ Client.prototype.prepend = function(key, value, callback) {
 Client.prototype.touch = function(key, expires, callback) {
   if(callback === undefined) {     
     var self = this;     
-    return new Promise(function(resolve, reject) { self.touch(key, expires, function(err, val) { err ? reject(err) : resolve(val); }); });
+    return promisify(function(callback) { self.touch(key, expires, function(err, success) { callback(err, success); }); });
   }
   // TODO: support version (CAS)
   var logger = this.options.logger;
@@ -569,8 +590,8 @@ Client.prototype.touch = function(key, expires, callback) {
 // `true` (if the operation was successful), or an error.
 Client.prototype.flush = function(callback) {
   if(callback === undefined) {     
-    var self = this;     
-    return new Promise(function(resolve, reject) { self.flush(function(err, val) { err ? reject(err) : resolve(val); }); });
+    var self = this;
+    return promisify(function(callback) { self.flush(function(err, results) { callback(err, results); }); });
   }
   // TODO: support expiration
   this.seq++;

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -15,12 +15,16 @@ test('GetSuccessful', function(t) {
   };
 
   var client = new MemJS.Client([dummyServer]);
-  client.get('hello', function(err, val, flags) {
+  var assertor = function(err, val, flags) {
     t.equal('world', val);
     t.equal('flagshere', flags);
     t.equal(null, err);
     t.equal(1, n, 'Ensure get is called');
-    t.end();
+  };
+  client.get('hello', assertor);
+  n = 0;
+  return client.get('hello').then(function(res) {
+    assertor(null, res.value, res.flags);
   });
 });
 
@@ -36,11 +40,16 @@ test('GetNotFound', function(t) {
   };
 
   var client = new MemJS.Client([dummyServer]);
-  client.get('hello', function(val, flags) {
+  var assertor = function(val, flags) {
     t.equal(null, val);
     t.equal(null, flags);
     t.equal(1, n, 'Ensure get is called');
     t.end();
+  };
+  client.get('hello', assertor);
+  n = 0;
+  return client.get('hello').then(function(res) {
+    assertor(null, res.value, res.extras);
   });
 });
 
@@ -56,11 +65,15 @@ test('SetSuccessful', function(t) {
   };
 
   var client = new MemJS.Client([dummyServer]);
-  client.set('hello', 'world', {}, function(err, val) {
+  var assertor = function(err, val) {
     t.equal(true, val);
     t.equal(null, err);
     t.equal(1, n, 'Ensure set is called');
-    t.end();
+  };
+  client.set('hello', 'world', {}, assertor);
+  n = 0;
+  return client.set('hello', 'world', {}).then(function (success){
+    assertor(null, success);
   });
 });
 
@@ -117,11 +130,15 @@ test('SetUnsuccessful', function(t) {
   };
 
   var client = new MemJS.Client([dummyServer]);
-  client.set('hello', 'world', {}, function(err, val) {
+  var assertor = function(err, val) {
     t.equal(null, val);
     t.equal('MemJS SET: ' + errors[3], err.message);
     t.equal(1, n, 'Ensure set is called');
-    t.end();
+  };
+  client.set('hello', 'world', {}, assertor);
+  n = 0;
+  return client.set('hello', 'world', {}).catch(function(err) {
+    assertor(err, null);
   });
 });
 
@@ -245,11 +262,15 @@ test('AddSuccessful', function(t) {
   };
 
   var client = new MemJS.Client([dummyServer], {expires: 1024});
-  client.add('hello', 'world', {}, function(err, val) {
+  var assertor = function(err, val) {
     t.equal(null, err);
     t.equal(true, val);
     t.equal(1, n, 'Ensure add is called');
-    t.end();
+  };
+  client.add('hello', 'world', {}, assertor);
+  n = 0;  
+  return client.add('hello', 'world', {}).then(function(success) {
+    assertor(null, success);
   });
 });
 
@@ -307,11 +328,15 @@ test('ReplaceSuccessful', function(t) {
   };
 
   var client = new MemJS.Client([dummyServer], {expires: 1024});
-  client.replace('hello', 'world', {}, function(err, val) {
+  var assertor = function(err, val) {
     t.equal(null, err);
     t.equal(true, val);
     t.equal(1, n, 'Ensure replace is called');
-    t.end();
+  };
+  client.replace('hello', 'world', {}, assertor);
+  n = 0;
+  return client.replace('hello', 'world', {}).then(function(success){
+    assertor(null, success);
   });
 });
 
@@ -367,11 +392,15 @@ test('DeleteSuccessful', function(t) {
   };
 
   var client = new MemJS.Client([dummyServer]);
-  client.delete('hello', function(err, val) {
+  var assertor = function(err, val) {
     t.equal(null, err);
     t.equal(true, val);
     t.equal(1, n, 'Ensure delete is called');
-    t.end();
+  };
+  client.delete('hello', assertor);
+  n = 0;
+  return client.delete('hello').then(function(success) {
+    assertor(null, success);
   });
 });
 
@@ -407,11 +436,15 @@ test('Flush',  function(t) {
   };
 
   var client = new MemJS.Client([dummyServer, dummyServer]);
-  client.flush(function(err, results) {
+  var assertor = function(err, results) {
     t.equal(null, err);
     t.equal(true, results['example.com:1234']);
     t.equal(2, n, 'Ensure flush is called for each server');
-    t.end();
+  };
+  client.flush(assertor);
+  n = 0;
+  return client.flush().then(function(results) {
+    assertor(null, results);
   });
 });
 


### PR DESCRIPTION
The previous conditions would always evaluate to false because
`typeof callback` evaluates to 'undefined' which is not equal to the 
symbol undefined